### PR TITLE
Run python with /usr/bin/env

### DIFF
--- a/dash.py
+++ b/dash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #    Copyright 2013 IBM Corp.
 #


### PR DESCRIPTION
Determine python interpreter to run based on the environment.  Allows
for running dash.py in a virtualenv.
