### PR TITLE
Don't divide by zero

### DIFF
--- a/dash.py
+++ b/dash.py
@@ -122,6 +122,9 @@ def get_job_status(change):
                     okay = 'maybe' if okay != 'no' else okay
                 else:
                     okay = 'no'
+    if total == 0:
+        # Don't divide by 0 :)
+        return 0, okay
     return (complete * 100) / total, okay
 
 

--- a/test_dash.py
+++ b/test_dash.py
@@ -54,6 +54,14 @@ class TestDash(unittest.TestCase):
         self.assertEqual(66, complete)
         self.assertEqual('maybe', okay)
 
+    def test_get_job_status_no_jobs(self):
+
+        change = {'jobs': []}
+
+        complete, okay = dash.get_job_status(change)
+        self.assertEqual(0, complete)
+        self.assertEqual(None, okay)
+
     def test_get_change_id(self):
         self.assertEqual(1234, dash.get_change_id({'id': '1234,10'}))
 


### PR DESCRIPTION
If there are no jobs for a change the calculation for the status of
those jobs led to a division by zero.  This is generally accepted to be
a Bad Thing(tm).