### PR TITLE
Update the readme about using --passwd for http auth

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,8 @@ Options:
   -h, --help            show this help message and exit
   -u USER, --user=USER  Gerrit username
   -P PASSWD, --passwd=PASSWD
-                        Gerrit password
+                        Gerrit password. For example, you can get this from
+                        https://review.openstack.org/#/settings/
   -r REFRESH, --refresh=REFRESH
                         Refresh in seconds
   -o OWNER, --owner=OWNER
@@ -54,3 +55,12 @@ Queue: check
    5: (32040,1 ) Moves scheduler.rpcapi.prep_resize call on compute.api to conductor
   13: (30822,6 ) Fix VMwareVCDriver to support multi-datastore
   15: (31952,8 ) xenapi: remove auto_disk_config check during resize
+
+
+Notes:
+
+* It used to be possible to just use your public ssh key for gerrit but with
+  the latest version of dash you have to supply your password for HTTP. So if
+  you are getting a 401 be sure that you are supplying the --user and --passwd
+  options on the command line and that the password matches what's in your
+  gerrit settings at https://review.openstack.org/#/settings/.


### PR DESCRIPTION
dash uses http auth since 9e2ad586ddc6826d0e9a60a292e746a71c3691ec.

For people like me that didn't realize this and expected it to just
keep working with my public ssh key that I use for gerrit, it's
confusing when you get a 401.

So this updates the README to point out that you need to have a
valid http password in your gerrit settings and use that with the -P
option now to connect.