### PR TITLE
Add -q option to support direct gerrit query

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,8 @@ Options:
                         Comma separated list of projects
   -t TOPIC, --topic=TOPIC
                         Show a particular topic only
+  -q QUERY, --query=QUERY
+                        Show changes according to a gerrit query
   -w, --watched         Show changes for all watched projects
   -s, --starred         Show changes for all starred commits
   -O OPERATOR, --operator=OPERATOR


### PR DESCRIPTION
So far showing commits from multiple topics or from multiple owner was
not possible. With newly introduced -q flag any type of gerrit_query
expression can be passed in.