### PR TITLE
Add the ability to specify multiple changes

### DIFF
--- a/README
+++ b/README
@@ -14,7 +14,8 @@ Options:
   -o OWNER, --owner=OWNER
                         Show patches from this owner
   -c CHANGE, --change=CHANGE
-                        Show a particular patch set
+                        Show a particular patch set.
+                        Can be specified multiple times.
   -p PROJECTS, --projects=PROJECTS
                         Comma separated list of projects
   -t TOPIC, --topic=TOPIC
@@ -55,6 +56,12 @@ Queue: check
    5: (32040,1 ) Moves scheduler.rpcapi.prep_resize call on compute.api to conductor
   13: (30822,6 ) Fix VMwareVCDriver to support multi-datastore
   15: (31952,8 ) xenapi: remove auto_disk_config check during resize
+
+$ ./dash.py -r 60 -c 523958 -c 532290
+Queue: check (2/134)
+     (523958,18) libvirt: QEMU native LUKS decryption for encrypted volumes
+     (532290,8) Add get_traits() method to ComputeDriver
+
 
 
 Notes:

--- a/dash.py
+++ b/dash.py
@@ -449,8 +449,9 @@ def opt_parse(argv):
                          default=0, type=int)
     optparser.add_option('-o', '--owner', default=None,
                          help='Show patches from this owner')
-    optparser.add_option('-c', '--change', default=None,
-                         help='Show a particular patch set')
+    optparser.add_option('-c', '--change', default=None, action='append',
+                         help='Show a particular patch set. '
+                              'Can be specified multiple times.')
     optparser.add_option('-p', '--projects', default='',
                          help='Comma separated list of projects')
     optparser.add_option('-t', '--topic', default=None,
@@ -517,10 +518,15 @@ def main():
         dump_gerrit(auth_creds, filters, opts.operator, projects)
         return
 
+    # If there are multiple changes, we have to use the OR operator.
+    operator = opts.operator
+    if len(filters.get('change', [])) > 1:
+        operator = 'OR'
+
     while True:
         try:
             do_dashboard(auth_creds, opts.user, filters, opts.refresh != 0,
-                         opts.jenkins, opts.operator, projects)
+                         opts.jenkins, operator, projects)
             if not opts.refresh:
                 break
             time.sleep(opts.refresh)


### PR DESCRIPTION
Sometimes it's nice to be able to monitor multiple
changes from different owners in different projects.
This changes the -c option to be a list so you can
specify multiple changes at once.

Since the gerrit query language only handles multiple
changes with an OR (AND means none are shown), if multiple
changes are shown, the operator option is hard-coded to 'OR'.