### PR TITLE
Show queued jobs without executor

### DIFF
--- a/dash.py
+++ b/dash.py
@@ -393,7 +393,9 @@ def do_dashboard(auth_creds, user, filters, reset, show_jenkins, operator,
                     elif okay == 'maybe':
                         print(yellow_line(line))
                     elif status == '?':
-                        continue
+                        # status == ? means the patch is queued but
+                        # no executor is available
+                        print(line)
                     else:
                         print(red_line(line))
                 elif change.get('starred'):


### PR DESCRIPTION
When zuul returned '?' as a status for a patch this tools skipped that
patch. This is missleading as the job is actually queued but missing
executor. This commit changes the tool to shows these jobs with default
foreground and background color.