### PR TITLE
Fix zuul URL

### DIFF
--- a/dash.py
+++ b/dash.py
@@ -100,7 +100,7 @@ def dump_gerrit(auth_creds, filters, operator, projects, query):
 
 
 def _get_zuul_status():
-    req = urllib2.Request('https://zuul.openstack.org/status')
+    req = urllib2.Request('https://zuul.openstack.org/api/status')
     req.add_header('Accept-encoding', 'gzip')
     # NOTE(SamYaple): We don't really care about verifying the cert, and the
     # url tends to be in and out of having a valid cert, esspecially with


### PR DESCRIPTION
The REST API URL changed recently. I'm told the OpenStack zuul
REST API is:

"undocumented and subject to change without notice.  use at own risk."

So let's whack this mole.